### PR TITLE
Rename package to avoid conflicts

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
-name = "AlphaZero"
+name = "AlphaZeroTP"
 uuid = "8ed9eb0b-7496-408d-8c8b-2119aeea02cd"
-authors = ["Jonathan Laurent <jonathan.laurent@cs.cmu.edu>, forked by Andrew Lambe <andrew.b.lambe@gmail.com"]
-version = "0.5.6"
+authors = ["Andrew Lambe <andrew.b.lambe@gmail.com>, forked from AlphaZero.jl by Jonathan Laurent <jonathan.laurent@cs.cmu.edu>"]
+version = "0.5.7"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"


### PR DESCRIPTION
- so that we can tell the difference between internal and external implementations of AlphaZero