### PR TITLE
Enable finetuning from a base model

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlphaZeroTP"
 uuid = "62478450-e654-4b43-b20a-c9dae170cc77"
 authors = ["Andrew Lambe <andrew.b.lambe@gmail.com>, forked from AlphaZero.jl by Jonathan Laurent <jonathan.laurent@cs.cmu.edu>"]
-version = "0.6.0"
+version = "0.7.0"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/src/ui/session.jl
+++ b/src/ui/session.jl
@@ -90,7 +90,11 @@ function valid_session_dir(dir)
 end
 
 function valid_finetuning_session_dir(dir)
-  isfile(joinpath(dir, BESTNN_FILE))
+  isfile(joinpath(dir, BESTNN_FILE)) &&
+  !isfile(joinpath(dir, PARAMS_FILE)) &&
+  !isfile(joinpath(dir, CURNN_FILE)) &&
+  !isfile(joinpath(dir, MEM_FILE)) &&
+  !isfile(joinpath(dir, ITC_FILE))
 end
 
 function save_env(env::Env, dir)

--- a/src/ui/session.jl
+++ b/src/ui/session.jl
@@ -297,6 +297,7 @@ function Session(
     Log.section(logger, 1, "Loading finetuning environment from: $dir")
     # The network must be compatible with the parameters defined in experiment e
     curnn = load(joinpath(dir, CURNN_FILE))["curnn"]
+    curnn.gspec = e.gspec
     env = Env(e.gspec, e.params, curnn)
     session = Session(env, dir, logger, autosave, save_intermediate, e.benchmark)
     session.report = SessionReport()

--- a/src/ui/session.jl
+++ b/src/ui/session.jl
@@ -90,7 +90,7 @@ function valid_session_dir(dir)
 end
 
 function valid_finetuning_session_dir(dir)
-  isfile(joinpath(dir, CURNN_FILE))
+  isfile(joinpath(dir, BESTNN_FILE))
 end
 
 function save_env(env::Env, dir)
@@ -296,7 +296,7 @@ function Session(
   elseif valid_finetuning_session_dir(dir)
     Log.section(logger, 1, "Loading finetuning environment from: $dir")
     # The network must be compatible with the parameters defined in experiment e
-    curnn = load(joinpath(dir, CURNN_FILE))["curnn"]
+    curnn = load(joinpath(dir, BESTNN_FILE))["bestnn"]
     curnn.gspec = e.gspec
     env = Env(e.gspec, e.params, curnn)
     session = Session(env, dir, logger, autosave, save_intermediate, e.benchmark)


### PR DESCRIPTION
- If the target directory contains only the best previous neural net, allow the user to start a new training run with new parameters using that previous best network as a starting point